### PR TITLE
main.py: replace --nowait with --wait

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -116,7 +116,7 @@ following displayed:
                             Specifies a file of commands to process.
       -d, --debug           Enable debug features
       -n, --nocolor         Turn off colorized output
-      --nowait              Don't wait for serial port
+      --wait                How long to wait for serial port
       --timing              Print timing information about each command
       --quiet               Turns off some output (useful for testing)
 

--- a/README.rst
+++ b/README.rst
@@ -42,6 +42,12 @@ You can install rshell using the command:
 If you use a virtualenv, then you don't need the sudo. rshell needs Python3.
 All of my testing was done using version 3.4.0.
 
+Debian/Ubuntu users can get pip3 using:
+
+::
+
+    sudo apt-get install python3-pip
+
 Sample Session
 ==============
 
@@ -160,12 +166,12 @@ By default, rshell uses ANSI color escape codes when displaying the
 prompt and ls output. This option allows colorized output to be
 disabled.
 
---nowait
---------
+--wait
+------
 
-If a port is specified, then rshell will wait for the serial port to exist
-before continuing. With the --nowait option, rshell will not wait for the
-serial port to exist.
+If a port is specified defines how long rshell will wait for the port to exist
+and for a connection to be established. The default is 0 seconds specifying an
+immediate return.
 
 -p PORT, --port PORT
 --------------------

--- a/rshell/main.py
+++ b/rshell/main.py
@@ -12,7 +12,7 @@
 # from __future__ import print_function
 
 from rshell.getch import getch
-from rshell.pyboard import Pyboard
+from rshell.pyboard import Pyboard, PyboardError
 
 import argparse
 import binascii
@@ -963,7 +963,7 @@ def add_arg(*args, **kwargs):
     return (args, kwargs)
 
 
-def connect(port, baud=115200, user='micro', password='python', wait=False):
+def connect(port, baud=115200, user='micro', password='python', wait=0):
     """Tries to connect automagically vie network or serial."""
     try:
         ip_address = socket.gethostbyname(port)
@@ -991,7 +991,7 @@ def connect_telnet(name, ip_address=None, user='micro', password='python'):
     add_device(dev)
 
 
-def connect_serial(port, baud=115200, wait=False):
+def connect_serial(port, baud=115200, wait=0):
     """Connect to a MicroPython board via a serial port."""
     if not QUIET:
         print('Connecting to %s ...' % port)
@@ -1157,13 +1157,16 @@ class DeviceSerial(Device):
         self.wait = wait
 
         if wait and not os.path.exists(port):
+            toggle = False
             try:
-                sys.stdout.write("Waiting for serial port '%s' to exist" % port)
+                sys.stdout.write("Waiting %d seconds for serial port '%s' to exist" % (wait, port))
                 sys.stdout.flush()
-                while not os.path.exists(port):
+                while wait and not os.path.exists(port):
                     sys.stdout.write('.')
                     sys.stdout.flush()
                     time.sleep(0.5)
+                    toggle = not toggle
+                    wait = wait if not toggle else wait -1
                 sys.stdout.write("\n")
             except KeyboardInterrupt:
                 raise DeviceError('Interrupted')
@@ -1172,9 +1175,10 @@ class DeviceSerial(Device):
         self.dev_name_long = '%s at %d baud' % (port, baud)
 
         try:
-            pyb = Pyboard(port, baudrate=baud)
-        except serial.serialutil.SerialException as err:
-            raise DeviceError(str(err))
+            pyb = Pyboard(port, baudrate=baud, wait=wait)
+        except PyboardError as err:
+            print(err)
+            sys.exit(1)
 
         # Bluetooth devices take some time to connect at startup, and writes
         # issued while the remote isn't connected will fail. So we send newlines
@@ -2167,11 +2171,12 @@ def main():
         default=False
     )
     parser.add_argument(
-        "--nowait",
+        "--wait",
         dest="wait",
-        action="store_false",
-        help="Don't wait for serial port",
-        default=True
+        type=int,
+        action="store",
+        help="Seconds to wait for serial port",
+        default=0
     )
     parser.add_argument(
         "--timing",


### PR DESCRIPTION
Now my change to pyboard.py has been accepted, where a port is specified this provides an option to wait for the board to exist and to become available.

I've also added a note to the README on how to acquire pip3.