### PR TITLE
Avoid call to autoconnect when sys.platform == 'darwin' (OSX)

### DIFF
--- a/rshell/main.py
+++ b/rshell/main.py
@@ -2231,7 +2231,8 @@ def main():
             print(err)
     else:
         autoscan()
-    autoconnect()
+    if sys.platform != 'darwin':
+        autoconnect()
 
     if args.filename:
         with open(args.filename) as cmd_file:


### PR DESCRIPTION
As per [dhylands/rshell/issues/1](https://github.com/dhylands/rshell/issues/1)