### PR TITLE
rsync and cp -r added. cp, ls, and rm match wildcards.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -299,12 +299,35 @@ cp
 
 ::
 
-    cp SOURCE DEST
+    usage: cp SOURCE DEST
     cp SOURCE... DIRECTORY
+    cp [-r|--recursive] [SOURCE|SRC_DIR]... DIRECTORY
+    cp [-r|--recursive] PATTERN DIRECTORY
+
+    positional arguments:
+      DEST             A destination file
+      SOURCE           File to copy
+      SRC_DIR          Directory to copy
+      PATTERN          File or directory pattern match string e.g. foo/*.py
+
+    optional arguments:
+      -h, --help       show this help message and exit
+      -r, --recursive  copy directories recursively
 
 Copies the SOURCE file to DEST. DEST may be a filename or a directory
 name. If more than one source file is specified, then the destination
 should be a directory.
+
+Directories will only be copied if -r is specified.
+
+A single pattern may be specified, in which case the destination
+should be a directory. Pattern matching is performed according to a subset
+of the Unix rules (see below). 
+
+Recursive copying uses rsync (see below): where a file exists on source
+and destination, it will only be copied if the source is newer than the
+destination.
+
 
 echo
 ----
@@ -366,17 +389,22 @@ ls
 
 ::
 
-    usage: ls [-a] [-l] FILE...
+    usage: ls [-a] [-l] [FILE|DIRECTORY|PATTERN]...
 
     List directory contents.
 
     positional arguments:
-      FILE        Files or directories to list
+      FILE        File to list (show absolute path)
+      DIRECTORY   Directory (list contents)
+      PATTERN     File or directory pattern match string e.g. foo/*.py
 
     optional arguments:
       -h, --help  show this help message and exit
       -a, --all   do not ignore hidden files
       -l, --long  use a long listing format
+
+Pattern matching is performed according to a subset of the Unix rules
+(see below). 
 
 mkdir
 -----
@@ -419,17 +447,55 @@ rm
 
 ::
 
-    usage: rm [-r|--recursive][-f|--force] FILE...
+    usage: rm [-f|--force] FILE...
+    rm [-f|--force] PATTERN
+    rm -r [-f|--force] PATTERN
+    rm -r [-f|--force] [FILE|DIRECTORY]...
 
-    Removes files or directories (directories must be empty).
+    Removes files or directories (including their contents).
 
     positional arguments:
       FILE             File to remove
+      DIRECTORY        Directory to remove (-r required)
+      PATTERN          File matching pattern e.g. *.py
 
     optional arguments:
       -h, --help       show this help message and exit
       -r, --recursive  remove directories and their contents recursively
       -f, --force      ignore nonexistant files and arguments
+
+A single pattern may be specified. Pattern matching is performed
+according to a subset of the Unix rules (see below). Directories
+can only be removed if the recursive argument is provided.
+
+Beware of rm -r * or worse.
+
+rsync
+-----
+
+::
+
+    usage: rsync [-m|--mirror] [-n|--dry-run] [-v|--verbose] SRC_DIR DEST_DIR
+
+    Recursively synchronises a source directory to a destination.
+    Directories must exist.
+
+    positional arguments:
+      SRC_DIR          Directory containing source files.
+      DEST_DIR         Directory for destination
+
+    optional arguments:
+      -h, --help       show this help message and exit
+      -m, --mirror     remove files or directories from destination if
+                       absent from source.
+      -n, --dry-run    make no changes but report what would be done. Implies -v
+      -v, --verbose    report changes made.
+
+
+Synchronisation is performed by comparing the date and time of source
+and destination files. Files are copied if the source is newer than the
+destination.
+
 
 shell
 -----
@@ -448,3 +514,18 @@ This will invoke a command, and return back to rshell. Example:
     !make deploy
 
 will flash the pyboard.
+
+Pattern Matching
+================
+
+This is performed according to a subset of the Unix rules. The limitations
+are that wildcards are only allowed in the rightmost directory of a path and
+curly bracket {} syntax is unsupported:
+
+::
+
+    *.py Match files in current directory with a .py extension
+    temp/x[0-9]a.* Match temp/x1a.bmp but not temp/x00a.bmp
+
+    t*/*.bmp Invalid: will produce an error message
+    {*.doc,*.pdf} Invalid: will produce an error message

--- a/tests/test-rshell.sh
+++ b/tests/test-rshell.sh
@@ -2,12 +2,13 @@
 
 # set -x
 
-LOCAL_DIR='./rshell-test'
+LOCAL_DIR="./rshell-test"
 
 RSHELL_DIR=rshell
 TESTS_DIR=tests
 
-RSHELL="$(pwd)/${RSHELL_DIR}/main.py --quiet --nocolor"
+#RSHELL="$(pwd)/${RSHELL_DIR}/main.py --quiet --nocolor"
+RSHELL="$(pwd)/r.py --quiet --nocolor"
 MAKE_ALL_BYTES="$(pwd)/${TESTS_DIR}/make_all_bytes.py"
 
 cmp_results() {
@@ -76,14 +77,92 @@ EOF
     ${RSHELL} rm -rf test-out
 }
 
+make_tree() {
+    dirname=$1
+    content="Pyboard test"
+    rm -r ${dirname} 2> /dev/null
+    mkdir ${dirname}
+    echo ${content} > ${dirname}/file1
+    echo ${content} > ${dirname}/file2
+    mkdir ${dirname}/sub
+    echo ${content} > ${dirname}/sub/file1
+    echo ${content} > ${dirname}/sub/file2
+}
+
+report() {
+    if [ $1 -eq 0 ]; then
+        echo $2 " - PASS"
+    else
+        echo $2 " - FAIL"
+        exit 1
+    fi
+    echo
+}
+
+rsync_test() {
+    # rsync tests
+    local LOCAL_ROOT="/tmp"
+    local REMOTE_ROOT="/sd"
+    local TMP_REF="pyboard_ref"
+    local TMP_OUT="pyboard_out"
+    local TMP_RESULT="pyboard"
+    local TREE_CMP="$(pwd)/${TESTS_DIR}/tree_cmp.py"
+#    local FLAGS=""
+    local FLAGS="--verbose"
+
+    echo
+    make_tree ${LOCAL_ROOT}/${TMP_REF} # Unchanging
+    make_tree ${LOCAL_ROOT}/${TMP_OUT} # Subject to deletions
+
+    THIS_TEST="rsync test basic"
+    echo Testing ${THIS_TEST}
+    ${RSHELL} rm -r ${REMOTE_ROOT}/${TMP_RESULT} 2> /dev/null
+    ${RSHELL} mkdir ${REMOTE_ROOT}/${TMP_RESULT}
+    ${RSHELL} cp -r ${LOCAL_ROOT}/${TMP_OUT}/* ${REMOTE_ROOT}/${TMP_RESULT}
+
+    rm -r ${LOCAL_ROOT}/${TMP_RESULT} 2> /dev/null
+    mkdir ${LOCAL_ROOT}/${TMP_RESULT}
+    ${RSHELL} cp -r ${REMOTE_ROOT}/${TMP_RESULT}/* ${LOCAL_ROOT}/${TMP_RESULT}
+    ${TREE_CMP} ${LOCAL_ROOT}/${TMP_OUT} ${LOCAL_ROOT}/${TMP_RESULT} ${FLAGS}
+    report $? "${THIS_TEST}"
+
+    # Sync without -m but one file missing from source
+    THIS_TEST="rsync test no delete"
+    echo Testing ${THIS_TEST}
+    rm ${LOCAL_ROOT}/${TMP_OUT}/sub/file1
+    ${RSHELL} rsync ${FLAGS} ${LOCAL_ROOT}/${TMP_OUT} ${REMOTE_ROOT}/${TMP_RESULT}
+    ${RSHELL} rsync ${FLAGS} ${REMOTE_ROOT}/${TMP_RESULT} ${LOCAL_ROOT}/${TMP_RESULT}
+    ${TREE_CMP} ${LOCAL_ROOT}/${TMP_REF} ${LOCAL_ROOT}/${TMP_RESULT} ${FLAGS}
+    report $? "${THIS_TEST}"
+
+    THIS_TEST="rsync test delete file"
+    echo Testing ${THIS_TEST}
+    ${RSHELL} rsync ${FLAGS} -m ${LOCAL_ROOT}/${TMP_OUT} ${REMOTE_ROOT}/${TMP_RESULT}
+    ${RSHELL} rsync ${FLAGS} -m ${REMOTE_ROOT}//${TMP_RESULT} ${LOCAL_ROOT}/${TMP_RESULT}
+    ${TREE_CMP} ${LOCAL_ROOT}/${TMP_OUT} ${LOCAL_ROOT}/${TMP_RESULT} ${FLAGS}
+    report $? "${THIS_TEST}"
+
+    THIS_TEST="rsync test delete directory"
+    echo Testing ${THIS_TEST}
+    rm -r ${LOCAL_ROOT}/${TMP_OUT}/sub
+    ${RSHELL} rsync ${FLAGS} -m ${LOCAL_ROOT}/${TMP_OUT} ${REMOTE_ROOT}/${TMP_RESULT}
+    ${RSHELL} rsync ${FLAGS} -m ${REMOTE_ROOT}/${TMP_RESULT} ${LOCAL_ROOT}/${TMP_RESULT}
+    ${TREE_CMP} ${LOCAL_ROOT}/${TMP_OUT} ${LOCAL_ROOT}/${TMP_RESULT} ${FLAGS}
+    report $? "${THIS_TEST}"
+
+    echo Removing test data
+    ${RSHELL} rm -r ${REMOTE_ROOT}/${TMP_RESULT}
+    rm -r ${LOCAL_ROOT}/${TMP_REF} 2> /dev/null
+    rm -r ${LOCAL_ROOT}/${TMP_OUT} 2> /dev/null
+    rm -r ${LOCAL_ROOT}/${TMP_RESULT} 2> /dev/null
+}
+
 test_dir ${LOCAL_DIR}
 echo
 ROOT_DIRS=$(${RSHELL} ls /pyboard)
 for root_dir in ${ROOT_DIRS}; do
     test_dir /${root_dir}rshell-test
 done
-
+rsync_test
+echo
 echo "PASS"
-
-
-

--- a/tests/tree_cmp.py
+++ b/tests/tree_cmp.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python3
+
+"""Test program which compares two directory trees on local system
+args:
+full path to directory 1
+full path to directory 2
+(optional) --verbose
+Exit value 0 on success 1 on fail
+"""
+import sys
+import os
+
+
+def main():
+    verbose = len(sys.argv) == 4 and sys.argv[3] == '--verbose'
+    source = sys.argv[1]
+    dest = sys.argv[2]
+    source_list = [x[1:] for x in os.walk(source)]
+    dest_list = [x[1:] for x in os.walk(dest)]
+    lens = len(source_list)
+    if lens != len(dest_list):
+        if verbose:
+            print('Length fail ', lens, len(dest_list))
+        sys.exit(1)
+    for subdir in range(lens):
+        if False in map(lambda str0, str1 : str0 == str1, source_list[subdir], dest_list[subdir]):
+            if verbose:
+                print('Subdir fail ', source_list[subdir], dest_list[subdir])
+            sys.exit(1)
+    if verbose:
+        print('Directories match')
+    sys.exit(0)
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
A few notes on the code.

rsync() initially performs a check for an empty string. This hack reduced failures when accessing /flash. As discussed these failures were caused by a cache problem. The check can be removed when the cache problem is fixed.

I needed a print_err() function with global scope. I changed Shell.print_err() method to a function and altered the code to use this throughout.

test-rshell.sh uses the SD card for rsync tests because of the cacheing issue. The target directory and the level of verbosity are set by local variables.

The function find_macthing_files (sic) is unused. I have left it in place.
