### PR TITLE
Multiple Python commands accepted.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -442,6 +442,13 @@ For example, you could use:
 
 and it will boot the pyboard into DFU.
 
+If you want to execute multiple Python commands these should be separated
+by the ~ character (not the ; character):
+
+::
+
+    rshell.py repl ~ import mymodule ~ mymodule.run()
+
 rm
 --
 

--- a/rshell/main.py
+++ b/rshell/main.py
@@ -2275,6 +2275,7 @@ class Shell(cmd.Cmd):
                 if line[-1] == '~':
                     line = line[:-1]
                     self.quit_when_no_output = True
+                line = ';'.join(line.split('~'))
                 dev.write(bytes(line, encoding='utf-8'))
                 dev.write(b'\r')
             if not self.quit_when_no_output:


### PR DESCRIPTION
This one-line change is something I've found to be a time saver. It allows you to run more than one Python command:
```
 > repl ~ import mymodule ~ import mymodule.test()
```
The ~ character is mapped to ; before sending it to the REPL.
