### PR TITLE
Removed option to erase local disk with rsync and improved docs

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,7 +1,7 @@
 rshell
 =========
 
-Remote MicroPytyhon shell.
+Remote MicroPython shell.
 
 This is a simple shell which runs on the host and uses MicroPython's
 raw-REPL to send python snippets to the pyboard in order to get
@@ -89,7 +89,7 @@ Command Line Options
 -h, --help
 ----------
 
-Displays a lit of the valid options. You should get something like the
+Displays a list of the valid options. You should get something like the
 following displayed:
 
 ::
@@ -228,25 +228,38 @@ exit. Examples:
     rshell cp somefile.py /flash
     rshell repl ~ pyb.bootloader() ~
 
-File System
+Board Names
 ===========
 
-rshell can be connected to multiple pyboards simultaneously. If the
-board module exists on the pyboard (i.e. a file named board.py somewhere
+rshell can be connected to multiple pyboards simultaneously. If a
+`board` module exists on the pyboard (i.e. a file named `board.py` somewhere
 in the module search path) and it contains an attribute called name then
 the pyboard will use that name. If the board module can't be imported
 then the board will be named, pyboard or wipy. Names will have -1 (or
 some other number) to make the board name unique.
 
-You can access the internal flash on the first board connected using
-/flash and the sd card on the first board connected can be accessed
-using /sd.
+File System
+===========
 
-For all other connected pyboards, you can use /board-name/flash or
-/board-name/sd (you can see the board names using the boards command).
+PyBoards
+--------
+
+You can access the internal flash on the first board connected using
+`/flash` and the sd card on the first board connected can be accessed
+using `/sd`.
+
+For all other connected pyboards, you can use `/board-name/flash` or
+`/board-name/sd` (you can see the board names using the boards command).
 
 The boards command will show all of the connected pyboards, along with all of
 the directories which map onto that pyboard.
+
+ESP8266
+-------
+
+ESP8266 boards do not have /flash or /sd directories.
+
+The internal flash filesystem can be accessed via `/board-name` or `/pyboard` if the board has no name.
 
 Commands
 ========
@@ -496,8 +509,8 @@ rsync
     Directories must exist.
 
     positional arguments:
-      SRC_DIR          Directory containing source files.
-      DEST_DIR         Directory for destination
+      SRC_DIR          Local directory containing source files.
+      DEST_DIR         Device directory for destination
 
     optional arguments:
       -h, --help       show this help message and exit

--- a/rshell/main.py
+++ b/rshell/main.py
@@ -773,6 +773,18 @@ def make_dir(dst_dir, dry_run, print_func, recursed):
 
 def rsync(src_dir, dst_dir, mirror, dry_run, print_func, recursed):
     """Synchronizes 2 directory trees."""
+    # Verify that the destination path refers to a device path and not a local path.
+    # If dst_dir == '/' and mirror == true for example it could result in the local hard disk being wiped
+    dst_dev, _ = get_dev_and_path(dst_dir)
+    if not dst_dev:
+        print_err('Destination refers to a local directory (are you missing /pyboard ?)')
+        return
+
+    src_dev, _ = get_dev_and_path(src_dir)
+    if src_dev:
+        print_err('Source refers to a device directory')
+        return
+
     # This test is a hack to avoid errors when accessing /flash. When the
     # cache synchronisation issue is solved it should be removed
     if not isinstance(src_dir, str) or not len(src_dir):


### PR DESCRIPTION
This change restricts the usage of rsync slightly but prevents the user from unintentionally wiping their local disk

While rsync traditionally allows local or remote directories as SRC and DEST dirs, I don't think that makes sense here:

- rshell doesn't clearly differentiate between local and remote paths, you have to know that /device-name, /flash and /sd are remote while everything else is local
- almost all use cases of rsync will involve copying local source files to a remote micropython device
- in the remaining cases where you want to pull remote files back to the local host, you can use --mirror

Requiring SRC_DIR to be local and DEST_DIR to be remote doesn't remove any functionality, it just makes the usage of rsync clearer and prevents people inadvertently wiping their local hard drive by trying to copy to / !