### PR TITLE
Clarification for ESP based board when accessing their filesystem

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -16,7 +16,8 @@ into and out of your pyboard.
 
 When using the commands, the /flash directory, and the /sdcard directory
 (if an sdcard is inserted) are considered to be on the pyboard, and all
-other directories are considered to be on the host.
+other directories are considered to be on the host. For an ESP based board you
+can only reference its directory by using the board name e.g. /pyboard etc..
 
 NOTE: rshell requires a fairly recent version of the MicroPython
 firmware, specifically one which contains the ubinascii.unhexlify
@@ -77,11 +78,11 @@ entering the repl and importing it.
 
     Micro Python v1.4.3-28-ga3a14b9 on 2015-05-21; PYBv1.0 with STM32F405RG
     Type "help()" for more information.
-    >>> 
+    >>>
     >>> import hello
     Hello World
-    >>> 
-    /home/dhylands/Dropbox/micropython/rshell> 
+    >>>
+    /home/dhylands/Dropbox/micropython/rshell>
 
 Command Line Options
 ====================
@@ -330,7 +331,7 @@ Directories will only be copied if -r is specified.
 
 A single pattern may be specified, in which case the destination
 should be a directory. Pattern matching is performed according to a subset
-of the Unix rules (see below). 
+of the Unix rules (see below).
 
 Recursive copying uses rsync (see below): where a file exists on source
 and destination, it will only be copied if the source is newer than the
@@ -412,7 +413,7 @@ ls
       -l, --long  use a long listing format
 
 Pattern matching is performed according to a subset of the Unix rules
-(see below). 
+(see below).
 
 mkdir
 -----


### PR DESCRIPTION
As a beginner using an ESP based board I was confused when couldn't find the /flash directory. Thus, made small addition in the README file that might help clarify for others. 