### PR TITLE
Address #60: Add pyreadline dependency for Windows platform

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -48,4 +48,8 @@ setup(
             'rshell=rshell.command_line:main'
         ],
     },
+    extras_require={
+        ':sys_platform == "win32"': [
+            'pyreadline']
+    }
 )


### PR DESCRIPTION
Thank you so much for this wonderful tool rshell, Dave and the community!
Here are the bits to add the missing Windows dependency. Light manual testing on Windows 10 seem to work.