### PR TITLE
Update getch.py

### DIFF
--- a/rshell/getch.py
+++ b/rshell/getch.py
@@ -47,7 +47,10 @@ class _GetchWindows:
 
     def __call__(self):
         import msvcrt
-        return msvcrt.getch()
+        ch =  msvcrt.getch()
+        if ch == b'\xe0':
+            ch = {b'H': b'\x10', b'P': b'\x0e', b'M': b'\x06', b'K': b'\x02'}[msvcrt.getch()]
+        return ch
 
 class _GetchMacCarbon:
     """


### PR DESCRIPTION
Adds support for arrow keys in repl.  Issue #75 

I have tested it and it works well for all 4 arrow keys in Windows 10 and assume will work for other windows versions.  I noticed in the Micropython code that there are alternate keys i.e. Ctrl-P or perhaps the arrow keys are alternate to the emacs ctrl keys. 

Up Arrow = Ctrl-P
Dn Arrow = Ctrl-N
Left Arrow = Ctrl-B
Right Arrow = Ctrl-F

I ran existing getch.py and tested output of the Ctrl key combinations and then added these to the call def.

