### PR TITLE
added the mv command

### DIFF
--- a/rshell/main.py
+++ b/rshell/main.py
@@ -678,6 +678,120 @@ def cp(src_filename, dst_filename):
     return False
 
 
+def remove_dir(dirname):
+    """removes a directory"""
+    import os
+    try:
+        os.rmdir(dirname)
+    except OSError:
+        return False
+    return True
+
+
+def mv(src_filename, dst_filename, mv_mode):
+    """This isn't unix mv, it copies one file to another, then deletes the
+       source. The source file may be local or remote and the destination 
+       file may be local or remote, Options are handled differently no-clobber
+       and interactive answered 'no' halt execution giving error message
+       unable to mv source to destination 
+    """
+    def add_item(filename, new_item):
+        if filename[-1] != '/':
+            filename += '/'
+        return filename + new_item
+
+    src_dev, src_dev_filename = get_dev_and_path(src_filename)
+    dst_dev, dst_dev_filename = get_dev_and_path(dst_filename)
+    src_mode = auto(get_mode, src_filename)
+    dst_mode = auto(get_mode, dst_filename)
+    dst_exists = auto(get_stat, dst_filename) != (0, ) * 10
+    if mode_isdir(src_mode):
+        if not dst_exists:
+            try:
+                if not auto(make_directory, dst_filename):
+                    return False
+            except OSError:
+                return False
+            src_dir_contents = auto(listdir, src_filename)
+            for file_ in src_dir_contents:
+                if not mv(add_item(src_filename, file_), dst_filename, mv_mode):
+                    return False
+            return auto(remove_dir, src_filename)
+
+        src_dir_contents = auto(listdir, src_filename)
+        if src_filename[-1] == '/':
+            src_basename = os.path.basename(src_filename[:-1])
+        else:
+            src_basename = os.path.basename(src_filename)
+
+        #make the directory. it may already exist
+        auto(make_directory, add_item(dst_filename, src_basename))
+        
+        dst_filename = add_item(dst_filename, src_basename)
+
+        for file_ in src_dir_contents:
+            if not mv(add_item(src_filename, file_), dst_filename, mv_mode):
+                return False
+
+        return auto(remove_dir, src_filename)
+
+    src_basename = os.path.basename(src_filename)
+    if mode_isdir(dst_mode):
+        dst_dev_filename = add_item(dst_dev_filename, src_basename)
+        dst_filename = add_item(dst_filename, src_basename)
+
+    dst_dir_contents = auto(listdir, os.path.dirname(dst_filename))
+    # stop for no clobber when a file exist
+    if mv_mode == 'n' and src_basename in dst_dir_contents:
+        return False 
+
+    # Forced remove of the destination file
+    if mv_mode == 'f' and src_basename in dst_dir_contents:
+        if not auto(remove_file, resolve_path(dst_filename) , False, True):
+            return False
+        
+    if src_dev is dst_dev:
+        # src and dst are either on the same remote, or both are on the host
+        if auto(copy_file, src_filename, dst_dev_filename):
+            return auto(remove_file, src_filename, False, False)
+        else:
+            return False
+
+    filesize = auto(get_filesize, src_filename)
+
+    if dst_dev is None:
+        # Moving from remote to host
+        with open(dst_dev_filename, 'wb') as dst_file:
+            if src_dev.remote(send_file_to_host, src_dev_filename, dst_file,
+                              filesize, xfer_func=recv_file_from_remote):
+                return auto(remove_file, src_filename, False, False)
+            else:
+                return False
+                
+    if src_dev is None:
+        # Moving from host to remote
+        with open(src_dev_filename, 'rb') as src_file:
+            if dst_dev.remote(recv_file_from_host, src_file, dst_dev_filename,
+                              filesize, xfer_func=send_file_to_remote):
+                return auto(remove_file, src_filename, False, False)
+            else:
+                return False
+                
+
+    # Moving from remote A to remote B. We first copy the file
+    # from remote A to the host and then from the host to remote B
+    host_temp_file = tempfile.TemporaryFile()
+    if src_dev.remote(send_file_to_host, src_dev_filename, host_temp_file,
+                      filesize, xfer_func=recv_file_from_remote):
+        host_temp_file.seek(0)
+        if dst_dev.remote(recv_file_from_host, host_temp_file, dst_dev_filename,
+                          filesize, xfer_func=send_file_to_remote):
+            return auto(remove_file, src_filename, False, False)
+        else:
+            return False
+        
+    return False
+
 def eval_str(string):
     """Executes a string containing python code."""
     output = eval(string)
@@ -2083,6 +2197,85 @@ class Shell(cmd.Cmd):
         else:
             print_err('Unrecognized connection TYPE: {}'.format(connect_type))
 
+    argparse_mv = (
+        add_arg(
+            '-n', '--no-clobber',
+            dest='no_clobber',
+            action='store_true',
+            help='Never replace an existing destination file',
+            default=False
+        ),
+        add_arg(
+            '-f', '--force',
+            dest='force',
+            action='store_true',
+            help='Always replace a destination file if it exists',
+            default=False
+        ),
+        add_arg(
+            'filenames',
+            metavar='FILE',
+            nargs='+',
+            help='files and directories to move'
+        ),
+    )
+    
+    def complete_mv(self, text, line, begidx, endidx):
+        return self.filename_complete(text, line, begidx, endidx)
+
+    def do_mv(self, line):
+        """mv SOURCE DEST             move or rename a single file
+       mv SOURCE... DIRECTORY     move multiple files or directories to a destination directory
+       mv PATTERN DEST            move one or more files to a destination of the correct type
+       options -n --no-clobber     To determnine the action if the destination exists
+               -f --force
+        """
+
+        args = self.line_to_args(line)
+        mv_mode = None
+        if args.force and args.no_clobber:
+            print_err('--no-clobber or --force can only be specified')
+            return
+        if args.force:
+            mv_mode = 'f'
+        elif args.no_clobber:
+            mv_mode = 'n'
+        else:
+            mv_mode = ' '
+
+        if len(args.filenames) < 2:
+            print_err('Missing destination file')
+            return
+
+        dst_filename = args.filenames[-1]
+        src_filenames = args.filenames[:-1]
+        dst_resolved = resolve_path(dst_filename)
+        dst_mode = auto(get_mode, dst_resolved)
+        sfn = src_filenames[0]
+        if is_pattern(sfn):
+            if len(src_filenames) > 1:
+                print_err("Usage: mv PATTERN DIRECTORY")
+                return
+            src_filenames = process_pattern(sfn)
+            if src_filenames is None:
+                return
+        
+        if len(src_filenames) > 1:
+            if not mode_isdir(dst_mode):
+                err = "Destination {} is not a directory"
+                print_err(err.format(dst_filename))
+                return
+
+        for src_filename in src_filenames:
+            if is_pattern(src_filename):
+                print_err("Only one pattern permitted.")
+                return
+            
+            if not mv(resolve_path(src_filename), dst_resolved, mv_mode):
+                err = "Unable to move '{}' to '{}'"
+                print_err(err.format(src_filename, dst_filename))
+                break
+            
     def complete_cp(self, text, line, begidx, endidx):
         return self.filename_complete(text, line, begidx, endidx)
 

--- a/tests/make_tree.py
+++ b/tests/make_tree.py
@@ -1,0 +1,27 @@
+import os
+#move to sdcard if on remote 
+try:
+    os.chdir('/sd')
+except OSError:
+    pass
+
+os.mkdir('dir1')
+os.mkdir('dir2')
+
+def make_files(files):
+    for name in files:
+        with open(name, 'w') as f:
+            f.write('hello ')
+            f.write(name + '\n')
+
+make_files(('a.txt', 'b.txt', 'c.txt'))
+os.chdir('dir1')
+make_files(('d1a.txt', 'd1b.txt', 'd1c.txt'))
+os.chdir('../dir2')
+make_files(('d2a.txt', 'd2b.txt', 'd2c.txt'))
+os.mkdir('depth')
+os.chdir('depth')
+make_files(('depa.txt', 'depb.txt'))
+os.mkdir('deeper')
+os.chdir('deeper')
+make_files(('deepra.txt', 'deeprb.txt'))


### PR DESCRIPTION
This doesn't try to rename files using os.rename it's a copy and delete routine. It only deletes the source if the copy was successfully created.  It recursively moves directories, unlike rshell cp it doesn't rsync directories when acting recursively.  I thought if the source was being deletd an exact copy overwriting any destination made more sense.

unlike unix mv specifyinhg `--no-clobber` on an existing file halts execution, it keeps the logic simple.
I tried interactive but `reply = input()` (i didn't know a better way to ask a question) was presenting replies when pressing up arrow to retreive previous commands.
I've found a bug with argparse and reported it upstream.
`command --option source destination` works
`command soucre destination --option` works
but `command source --option destination` doesn't outputting the usage text block associated `do_command` method and outputs error message `command: error: unrecognize\
d arguments: destination`

How often is the vesion of rshell at PyPI updated to the curren commit?