### PR TITLE
Improve reporting for the "rsync" primitive

### DIFF
--- a/rshell/main.py
+++ b/rshell/main.py
@@ -932,6 +932,7 @@ def rsync(src_dir, dst_dir, mirror, dry_run, print_func, recursed, sync_hidden):
                       "'{}' is a directory. Ignoring"
                 print_err(msg.format(src_filename, dst_filename))
             else:
+                print_func('Checking {}'.format(dst_filename))
                 if stat_mtime(src_stat) > stat_mtime(dst_stat):
                     msg = "{} is newer than {} - copying"
                     print_func(msg.format(src_filename, dst_filename))


### PR DESCRIPTION
When uploading a larger code base to the device, rshell reports well about "Adding ..." files when actually uploading them. However, if timestamps haven't changed at all, it would be silent for a while, while checking all the files about whether they should be updated
without giving appropriate feedback to the user.

This change introduces a "Checking ..." message for each file in order to be more verbose about what is actually going on.