### PR TITLE
Fix set time

### DIFF
--- a/rshell/main.py
+++ b/rshell/main.py
@@ -950,21 +950,30 @@ def set_time(rtc_time):
         rtc = pyb.RTC()
         rtc.datetime(rtc_time)
     except:
-        # machine.RTC takes the arguments in a slightly different order:
-        # (year, month, day, hour, minute, second[, microsecond[, tzinfo]])
-        # http://docs.micropython.org/en/latest/library/machine.RTC.html#machine.RTC.init
-        rtc_time2 = (rtc_time[0], rtc_time[1], rtc_time[2], rtc_time[4], rtc_time[5], rtc_time[6])
         try:
+            import pycom
+            # PyCom's machine.RTC takes its arguments in a slightly different order
+            # than the official machine.RTC.
+            # (year, month, day, hour, minute, second[, microsecond[, tzinfo]])
+            # https://docs.pycom.io/firmwareapi/pycom/machine/rtc/#rtc-init-datetime-none-source-rtc-internal-rc
+            rtc_time2 = (rtc_time[0], rtc_time[1], rtc_time[2], rtc_time[4], rtc_time[5], rtc_time[6])
             import machine
             rtc = machine.RTC()
-            try:
-                # ESP8266 uses rtc.datetime() rather than rtc.init()
-                rtc.datetime(rtc_time2)
-            except:
-                # ESP32 (at least Loboris port) uses rtc.init()
-                rtc.init(rtc_time2)
+            rtc.init(rtc_time2)
         except:
-            pass
+            try:
+                # The machine.RTC documentation was incorrect and doesn't agree with the code, so no link
+                # is presented here. The order of the arguments is the same as the pyboard.
+                import machine
+                rtc = machine.RTC()
+                try:
+                    # ESP8266 uses rtc.datetime() rather than rtc.init()
+                    rtc.datetime(rtc_time)
+                except:
+                    # ESP32 (at least Loboris port) uses rtc.init()
+                    rtc.init(rtc_time)
+            except:
+                pass
 
 
 # 0x0D's sent from the host get transformed into 0x0A's, and 0x0A sent to the

--- a/rshell/main.py
+++ b/rshell/main.py
@@ -942,20 +942,27 @@ def rsync(src_dir, dst_dir, mirror, dry_run, print_func, recursed, sync_hidden):
 def set_time(rtc_time):
     rtc = None
     try:
-        # Pyboard (pyboard doesn't have machine.RTC())
+        # Pyboard (pyboard doesn't have machine.RTC()).
+        # The pyb.RTC.datetime function takes the arguments in the order:
+        # (year, month, day, weekday, hour, minute, second, subseconds)
+        # http://docs.micropython.org/en/latest/library/pyb.RTC.html#pyb.RTC.datetime
         import pyb
         rtc = pyb.RTC()
         rtc.datetime(rtc_time)
     except:
+        # machine.RTC takes the arguments in a slightly different order:
+        # (year, month, day, hour, minute, second[, microsecond[, tzinfo]])
+        # http://docs.micropython.org/en/latest/library/machine.RTC.html#machine.RTC.init
+        rtc_time2 = (rtc_time[0], rtc_time[1], rtc_time[2], rtc_time[4], rtc_time[5], rtc_time[6])
         try:
             import machine
             rtc = machine.RTC()
             try:
                 # ESP8266 uses rtc.datetime() rather than rtc.init()
-                rtc.datetime(rtc_time)
+                rtc.datetime(rtc_time2)
             except:
                 # ESP32 (at least Loboris port) uses rtc.init()
-                rtc.init(rtc_time)
+                rtc.init(rtc_time2)
         except:
             pass
 


### PR DESCRIPTION
@amotl - It looks like the machine.RTC documention is incorrect and doesn't agree with the code.

It seems that just the PyCom machine.RTC function takes the arguements in a different order, so I updated this PR to detect if its running on a pycom board by trying to import the pycom module.

I've tested this PR on a PyCom WiPy 3.0,  pyboard 1.1, a SparkFun ESP32 Thing, and Adafruit Huzzah 8266 feather and it now seems to work properly on all of those.

Could you test this on your board as well. Thanks