### PR TITLE
Be more patient in send_file_to_remote

### DIFF
--- a/rshell/main.py
+++ b/rshell/main.py
@@ -1051,12 +1051,12 @@ def send_file_to_remote(dev, src_file, dst_filename, filesize, dst_mode='wb'):
     """
     bytes_remaining = filesize
     save_timeout = dev.timeout
-    dev.timeout = 1
+    dev.timeout = 2
     while bytes_remaining > 0:
         # Wait for ack so we don't get too far ahead of the remote
         ack = dev.read(1)
         if ack is None or ack != b'\x06':
-            sys.stderr.write("timed out or error in transfer to remote\n")
+            sys.stderr.write("timed out or error in transfer to remote: {!r}\n".format(ack))
             sys.exit(2)
 
         if HAS_BUFFER:


### PR DESCRIPTION
I was experiencing many failures writing files to my PyBoard until I increased the timeout in `send_file_to_remote` from 1 s to 2 s. I have not had a timeout error since.

This should also resolve #117, assuming the WiPy experiences similar flash write times.