### PR TITLE
Add autoconnect support for LEGO Technic Large Hub

### DIFF
--- a/rshell/main.py
+++ b/rshell/main.py
@@ -238,6 +238,9 @@ def is_micropython_usb_device(port):
     # Check for Teensy VID:PID
     if usb_id.startswith('usb vid:pid=16c0:0483'):
         return True
+    # Check for LEGO Technic Large Hub
+    if usb_id.startswith('usb vid:pid=0694:0010'):
+        return True
     return False
 
 


### PR DESCRIPTION
I have a LEGO Mindstorms Inventor (51515) kit whose hub has USB VID:PID=0694:0010.  The following patch allows the autoconnect to work.  Thanks for rshell!
