### PR TITLE
Solves issue #152

### DIFF
--- a/rshell/main.py
+++ b/rshell/main.py
@@ -1853,10 +1853,10 @@ class Shell(cmd.Cmd):
 
     def set_prompt(self):
         if self.stdin == sys.stdin:
-            prompt = PROMPT_COLOR + cur_dir + END_COLOR + '> '
+            prompt = PROMPT_COLOR + cur_dir + END_COLOR + '>'
             if FAKE_INPUT_PROMPT:
                 print(prompt, end='')
-                self.prompt = ''
+                self.prompt = ' '
             else:
                 self.prompt = prompt
         else:


### PR DESCRIPTION
Prompt no longer disappears on inserting backspaces after a space.
Although keyboard shortcuts such as `CMD + <-` still erase prompt but those
can be avoided during active usage.