### PR TITLE
Fix flow of ACKs to ensure we do not hang on final buf write

### DIFF
--- a/rshell/main.py
+++ b/rshell/main.py
@@ -1093,8 +1093,6 @@ def recv_file_from_host(src_file, dst_filename, filesize, dst_mode='wb'):
             write_buf = bytearray(buf_size)
             read_buf = bytearray(buf_size)
             while bytes_remaining > 0:
-                # Send back an ack as a form of flow control
-                sys.stdout.write('\x06')
                 read_size = min(bytes_remaining, buf_size)
                 buf_remaining = read_size
                 buf_index = 0
@@ -1116,6 +1114,10 @@ def recv_file_from_host(src_file, dst_filename, filesize, dst_mode='wb'):
                 if hasattr(os, 'sync'):
                     os.sync()
                 bytes_remaining -= read_size
+
+                # Send back an ack as a form of flow control
+                sys.stdout.write('\x06')
+
         return True
     except:
         return False
@@ -1129,12 +1131,6 @@ def send_file_to_remote(dev, src_file, dst_filename, filesize, dst_mode='wb'):
     save_timeout = dev.timeout
     dev.timeout = 2
     while bytes_remaining > 0:
-        # Wait for ack so we don't get too far ahead of the remote
-        ack = dev.read(1)
-        if ack is None or ack != b'\x06':
-            sys.stderr.write("timed out or error in transfer to remote: {!r}\n".format(ack))
-            sys.exit(2)
-
         if HAS_BUFFER:
             buf_size = BUFFER_SIZE
         else:
@@ -1147,6 +1143,13 @@ def send_file_to_remote(dev, src_file, dst_filename, filesize, dst_mode='wb'):
             dev.write(buf)
         else:
             dev.write(binascii.hexlify(buf))
+
+        # Wait for ack so we don't get too far ahead of the remote
+        ack = dev.read(1)
+        if ack is None or ack != b'\x06':
+            sys.stderr.write("timed out or error in transfer to remote: {!r}\n".format(ack))
+            sys.exit(2)
+
         bytes_remaining -= read_size
     #sys.stdout.write('\r')
     dev.timeout = save_timeout


### PR DESCRIPTION
Using Windows 10 and a pyboard, often times a file transfer hangs and the only solution is to unplug the board and kill `rshell`. I observe this behaviour with 9 out of 10 larger file transfers (4KiB). Smaller transfers do not seem affected.

I'm not familiar enough with the specific mechanism of file transfer to describe the root cause here, but this behaviour appears to happen when `send_file_to_remote` has returned (no more data to send), but `recv_file_from_remote` is still executing, causing `Device.remote("recv_file_from_host", "send_file_to_remote" .. )` to hang indefinitely. Presumably waiting for more data that is never coming?

It seems the current code would never send/receive the final packet's ack, as they are processed at the start of the `while` loop. It is therefore possible for a last-packet timeout to go unnoticed by `rshell` . By ensuring acks are only sent _after_ the remote has received and written the packet, and subsequently verified after local has sent a full packet to the remote makes this more robust and indeed resolves my file transfer issues.
