### PR TITLE
import binascii if ubinascii not found

### DIFF
--- a/rshell/main.py
+++ b/rshell/main.py
@@ -1070,7 +1070,10 @@ def set_time(rtc_time):
 def recv_file_from_host(src_file, dst_filename, filesize, dst_mode='wb'):
     """Function which runs on the pyboard. Matches up with send_file_to_remote."""
     import sys
-    import ubinascii
+    try:
+        import ubinascii
+    except:
+        import binascii as ubinascii
     import os
     if HAS_BUFFER:
         try:
@@ -1182,7 +1185,10 @@ def recv_file_from_remote(dev, src_filename, dst_file, filesize):
 def send_file_to_host(src_filename, dst_file, filesize):
     """Function which runs on the pyboard. Matches up with recv_file_from_remote."""
     import sys
-    import ubinascii
+    try:
+        import ubinascii
+    except:
+        import binascii as ubinascii
     try:
         with open(src_filename, 'rb') as src_file:
             bytes_remaining = filesize
@@ -1233,7 +1239,10 @@ def test_readinto():
 
 def test_unhexlify():
     """Checks the micropython firmware to see if ubinascii.unhexlify exists."""
-    import ubinascii
+    try:
+        import ubinascii
+    except:
+        import binascii as ubinascii
     try:
         _ = ubinascii.unhexlify
         return True


### PR DESCRIPTION
Circuitpython uses binascii instead of ubinascii.
This PR adds a try/except to each import of ubinascii and if it fails, binascii is imported as unbinascii.

This allows shell to be used on CircuitPython Boards that support binascii.
Note: some of the "smaller" (e.g. samd21) builds of Circuitpython do not include binascii so rshell cannot be used for them.

This PR was created to support boards like the ESP32C3 which do not have access to the file system via USB. It is likely of limited use for other builds.

This was tested on  the ESP32-C3N4(espressif_esp32c3_devkit_1_n4) builds of CircuitPython which has the CircuitPython filesystem writeable by default. This is because the ESP32C3 has no native USB and the usual mounting of the file system as a USB device is not supported. shell is able to read and write to the ESP32C3 file system.

On most CircuitPython builds, the File System is read-only to CIrcuitPython (It is accessible as a USB drive). This means any attempts to write to /pyboard/ will fail. The file system can be made writeable by remounting it in a boot.py script but in general, just copying files to the USB device is much simpler. rshell can still be used to access the REPL and read from the file system. It was tested on an RP2040 Pico and a QTPY ESP32S2.

It was mostly created to demonstrate that the use os binascii in place of ubinascii works. This has come up in the past. See #179