### PR TITLE
Minor fixes

### DIFF
--- a/rshell/main.py
+++ b/rshell/main.py
@@ -3046,7 +3046,8 @@ def real_main():
               BUFFER_SIZE = USB_BUFFER_SIZE
           else:
               BUFFER_SIZE = UART_BUFFER_SIZE
-        QUIET or print('Using buffer-size of', BUFFER_SIZE)
+        if DEBUG:
+            print('Using buffer-size of', BUFFER_SIZE)
         try:
             connect(args.port, baud=args.baud, wait=args.wait, user=args.user, password=args.password)
         except DeviceError as err:

--- a/rshell/main.py
+++ b/rshell/main.py
@@ -1413,7 +1413,7 @@ def connect_telnet(name, ip_address=None, user='micro', password='python'):
 def connect_serial(port, baud=115200, wait=0):
     """Connect to a MicroPython board via a serial port."""
     if not QUIET:
-        print('Connecting to %s (buffer-size %d)...' % (port, BUFFER_SIZE))
+        print('Connecting to %s (buffer-size %d) ...' % (port, BUFFER_SIZE))
     try:
         dev = DeviceSerial(port, baud, wait)
     except DeviceError as err:
@@ -1729,7 +1729,7 @@ class DeviceSerial(Device):
             QUIET or sys.stdout.write('\n')
 
         # Send Control-C followed by CR until we get a >>> prompt
-        QUIET or print('Trying to connect to REPL ', end='', flush=True)
+        QUIET or print('Trying to connect to REPL ...', end='', flush=True)
         connected = False
         for _ in range(20):
             pyb.serial.write(b'\x03\r')

--- a/rshell/main.py
+++ b/rshell/main.py
@@ -792,6 +792,13 @@ def listdir(dirname):
     return os.listdir(dirname)
 
 
+def list_root_dirs():
+    """Returns a list of filenames contained in the named directory."""
+    import os
+    S_IFDIR = 0o40000
+    return [entry for entry in os.listdir('/') if os.stat('/' + entry)[0] & S_IFDIR]
+
+
 def listdir_matches(match):
     """Returns a list of filenames contained in the named directory.
        Only filenames which start with `match` will be returned.
@@ -1512,7 +1519,7 @@ class Device(object):
             if not unhexlify_exists:
                 raise ShellError('rshell needs MicroPython firmware with ubinascii.unhexlify')
         QUIET or print('Retrieving root directories ... ', end='', flush=True)
-        self.root_dirs = ['/{}/'.format(dir) for dir in self.remote_eval(listdir, '/')]
+        self.root_dirs = ['/{}/'.format(dir) for dir in self.remote_eval(list_root_dirs)]
         QUIET or print(' '.join(self.root_dirs))
         QUIET or print('Setting time ... ', end='', flush=True)
         now = self.sync_time()

--- a/rshell/main.py
+++ b/rshell/main.py
@@ -1388,11 +1388,9 @@ def connect(port, baud=115200, user='micro', password='python', wait=0):
     """Tries to connect automagically via network or serial."""
     try:
         ip_address = socket.gethostbyname(port)
-        #print('Connecting to ip', ip_address)
         connect_telnet(port, ip_address, user=user, password=password)
     except (socket.gaierror, ValueError):
         # Doesn't look like a hostname or IP-address, assume its a serial port
-        #print('connecting to serial', port)
         connect_serial(port, baud=baud, wait=wait)
 
 


### PR DESCRIPTION
Connection logging after applying these changes:

```text
> rshell --port /dev/cu.usbserial-01EDB820
Connecting to /dev/cu.usbserial-01EDB820 (buffer-size 32) ...
Trying to connect to REPL ... connected
Retrieving sysname ... esp32
Testing if ubinascii.unhexlify exists ... Y
Retrieving root directories ... /testdir/
Setting time ... Sep 25, 2022 09:45:09
Evaluating board_name ... pyboard
Retrieving time epoch ... Jan 01, 2000
Welcome to rshell. Use Control-D (or the exit command) to exit rshell.
```

- Buffer size is not logged twice
- All `operation ... result` messages follow the same format
- Root directories list only includes directories, no files