### PR TITLE
observe NO_COLOR from no-color.org

### DIFF
--- a/rshell/main.py
+++ b/rshell/main.py
@@ -2854,7 +2854,7 @@ def real_main():
     default_password = os.getenv('RSHELL_PASSWORD') or 'python'
     default_editor = os.getenv('RSHELL_EDITOR') or os.getenv('VISUAL') or os.getenv('EDITOR') or 'vi'
     default_color = sys.stdout.isatty()
-    default_nocolor = not default_color
+    default_nocolor = not default_color or (os.getenv('NO_COLOR') is not None)
     global BUFFER_SIZE
     try:
         default_buffer_size = int(os.getenv('RSHELL_BUFFER_SIZE'))


### PR DESCRIPTION
For visually impaired people, having color enabled on output poses daily challenges.  Many programs provide means to disable color -- however those flags are particular to the application (increasing burden on the user), or have environment variables that vary by application.
The site no-color.org suggests a simple NO_COLOR environment variable as a hint to applications (see https://no-color.org) as a simple way for "color impaired" people to disable color output.
This code leverages the NO_COLOR environment variable to set the same flag as the "-n" flag.