### PR TITLE
Check dir before listing - handle NotADirectoryError

### DIFF
--- a/rshell/main.py
+++ b/rshell/main.py
@@ -830,6 +830,8 @@ def listdir_matches(match):
             # This can happen when a symlink points to a non-existant file.
             pass
         return filename
+    if not os.path.isdir(dirname):
+        return []
     matches = [add_suffix_if_dir(result_prefix + filename)
                for filename in os.listdir(dirname) if filename.startswith(match_prefix)]
     return matches


### PR DESCRIPTION
Hello

This produces a crash

```sh
touch file
rshell

ls file
# if we press [TAB] it's fine 

ls file/
# if we press [TAB] we get a NotADirectoryError
```


With this tiny PR, this fix that by checking if the path is really a directory



<details>

<summary>For info the full traceback is</summary>

```
Traceback (most recent call last):
  File "/home/n4n5/.local/lib/python3.10/site-packages/rshell/main.py", line 2018, in filename_complete
    return self.real_filename_complete(text, line, begidx, endidx)
  File "/home/n4n5/.local/lib/python3.10/site-packages/rshell/main.py", line 2095, in real_filename_complete
    paths = sorted(auto(listdir_matches, abs_match))
  File "/home/n4n5/.local/lib/python3.10/site-packages/rshell/main.py", line 606, in auto
    return func(dev_filename, *args, **kwargs)
  File "/home/n4n5/.local/lib/python3.10/site-packages/rshell/main.py", line 834, in listdir_matches
    for filename in os.listdir(dirname) if filename.startswith(match_prefix)]
NotADirectoryError: [Errno 20] Not a directory: '/tmp/tmp.7pssVtEk3J/file'
```

</details>
