### PR TITLE
Don't try connect_telnet on Windows when '-p' is specified

### DIFF
--- a/rshell/main.py
+++ b/rshell/main.py
@@ -1419,7 +1419,7 @@ def add_arg(*args, **kwargs):
 
 def connect(port, baud=115200, user='micro', password='python', wait=0):
     """Tries to connect automagically via network or serial."""
-    if '/' in port:
+    if '/' in port or re.match("COM\\d+", port, re.IGNORECASE):
         connect_serial(port, baud=baud, wait=wait)
     else:
         try:


### PR DESCRIPTION
Hello,

I noticed this case can't work on Windows, because windows serial port name usually is: 'COMxx', not include '/'

https://github.com/dhylands/rshell/blob/56f75cf846b2fd89f9a89c08a9dabd8015c30931/rshell/main.py#L1420-L1427

So it always try `connect_telnet` and elapse more time.

#202